### PR TITLE
Remove redundant request header

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,8 +154,7 @@ export const getFragmentPixel = (imgW, imgH, x, y, w, h, cmpHeight) => {
 export const loadJSON = (jsonUrl, cb) => {
   fetch(jsonUrl, {
     mode: 'cors',
-    method: 'GET',
-    headers: { "Content-Type": "application/json; charset=utf-8" }
+    method: 'GET'
   })
   .then(res => res.json())
   .then(response => {


### PR DESCRIPTION
Content-Type is meaningless as a request header in a GET request.