### PR TITLE
Install missing babel-preset-es2015 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.0",
     "babel-preset-env": "^1.7.0",
+    "babel-preset-es2015": "^6.24.1",
     "css-loader": "^2.0.0",
     "expose-loader": "^0.7.5",
     "file-loader": "^4.2.0",


### PR DESCRIPTION
Because it is a build dependency that is not included, resulting in errors.